### PR TITLE
Handle non-numeric 'Aus'/'Off' states by mapping to 0 for IstLeistung…

### DIFF
--- a/main.js
+++ b/main.js
@@ -1048,6 +1048,21 @@ class WeishauptWem extends utils.Adapter {
                             if (valueArray[1]) {
                                 unit = valueArray[1];
                             }
+                            if (
+                                typeof value === "string" &&
+                                (value.toLowerCase() === "aus" || value.toLowerCase() === "off" || value === "--")
+                            ) {
+                                if (
+                                    labelWoSpaces === "IstLeistung" ||
+                                    labelWoSpaces === "SollLeistung" ||
+                                    labelWoSpaces.endsWith("Leistung") ||
+                                    unit === "kW" ||
+                                    unit === "%" ||
+                                    unit === "W"
+                                ) {
+                                    value = 0;
+                                }
+                            }
                             if (labelWoSpaces === "Status") {
                                 labelWoSpaces = labelWoSpaces + statusCount;
                                 statusCount++;


### PR DESCRIPTION
"IstLeistung" and "Sollleistung" return string "Aus" if the heat pump is off which cannot be mapped to a float value and fills the log with errors. Let´s set it to zero in that case.